### PR TITLE
builddocs paver task allow to control the output theme

### DIFF
--- a/pavement.py
+++ b/pavement.py
@@ -36,7 +36,7 @@ options(
 
 @task
 @cmdopts([
-    ('clean', 'c', 'clean out dependencies first'),
+    ('clean', 'c', 'clean out dependencies first')
 ])
 def setup(options):
     '''install dependencies'''
@@ -185,6 +185,9 @@ def create_settings_docs(options):
                         % (setting["label"], setting["description"]))
 
 @task
+@cmdopts([
+    ('sphinx_theme=', 's', 'Sphinx theme to use in documentation')
+])
 def builddocs(options):
     try:
         sh("git submodule init")
@@ -192,10 +195,14 @@ def builddocs(options):
     except:
         pass
     create_settings_docs(options)
-    cwd = os.getcwd()
-    os.chdir(options.sphinx.docroot)
-    sh("make html")
-    os.chdir(cwd)
+    if getattr(options, 'sphinx_theme', False):
+        # overrides default theme by the one provided in command line
+        set_theme = "-D html_theme='{}'".format(options.sphinx_theme)
+    else:
+        # Uses default theme defined in conf.py
+        set_theme = ""
+    sh("sphinx-build -a {} {} {}".format(set_theme, options.sphinx.sourcedir,
+                                         options.sphinx.builddir))
 
 @task
 def install_devtools():


### PR DESCRIPTION
For plugins documentation, we use more than one sphinx theme.

To publish plugins documentation in the Boundless connect portal, we use a Boundless Desktop theme called `boundless_product`.

![image](https://user-images.githubusercontent.com/3607161/31748297-209a804e-b46a-11e7-8d02-9846514bdaa4.png)

For documentation shipped with plugins as offline help, we use a generic boundless theme called `boundless_doc`. This is the default theme used as set in conf.py. The reasoning is that our plugins may be used in the official QGIS, so we better promote the company.

![image](https://user-images.githubusercontent.com/3607161/31748418-f113e738-b46a-11e7-946f-9086a7233a3d.png)

With this change (that I would extend to all our plugins) we can choose to use the default theme by running:

`paver builddocs`

Or choose the name of the alternative sphinx theme:

`paver builddocs -s boundless_product`




